### PR TITLE
Improve camera-based movement and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "AstroForge"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_tasks",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.16"
+bevy_tasks = "0.16"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
+use bevy::window::{CursorGrabMode, PrimaryWindow};
 
 mod player;
-use player::PlayerPlugin;
+use player::{CameraController, PlayerPlugin};
 
 fn main() {
     println!("🚀 AstroForge запускается...");
@@ -25,14 +26,25 @@ fn setup_scene(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    mut windows: Query<&mut Window, With<PrimaryWindow>>,
 ) {
     println!("✅ Настройка 3D сцены...");
     
     // Камера
     commands.spawn((
         Camera3d::default(),
+        CameraController {
+            distance: 10.0,
+            sensitivity: 0.002,
+            ..default()
+        },
         Transform::from_xyz(0.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
+
+    if let Ok(mut window) = windows.single_mut() {
+        window.cursor_options.visible = false;
+        window.cursor_options.grab_mode = CursorGrabMode::Locked;
+    }
 
     // Направленный свет (солнце)
     commands.spawn((


### PR DESCRIPTION
## Summary
- implement `CameraController` for mouse look
- update player movement relative to camera
- lock and hide cursor on startup
- add unit tests verifying movement directions

## Testing
- `cargo test --no-run`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68528e26c3d08325abb8f5c1343cd10b