### PR TITLE
Fix scene rendering

### DIFF
--- a/src/engine/renderer.rs
+++ b/src/engine/renderer.rs
@@ -322,7 +322,9 @@ fn create_floor_buffers(device: &wgpu::Device) -> (wgpu::Buffer, wgpu::Buffer, u
             color: [0.3, 0.3, 0.3],
         },
     ];
-    let indices: &[u16] = &[0, 1, 2, 2, 3, 0];
+    // WGPU expects counter-clockwise winding for front faces. Arrange the
+    // floor indices accordingly so the surface is visible from above.
+    let indices: &[u16] = &[0, 2, 1, 0, 3, 2];
     let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("Floor Vertex Buffer"),
         contents: bytemuck::cast_slice(&vertices),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ fn main() {
         let view =
             Mat4::from_quat(player.rotation).inverse() * Mat4::from_translation(-player.position);
         let aspect = engine.renderer.size.width as f32 / engine.renderer.size.height as f32;
-        let proj = Mat4::perspective_rh_gl(60f32.to_radians(), aspect, 0.1, 100.0);
+        // WGPU expects a projection matrix with a `[0, 1]` depth range.
+        let proj = Mat4::perspective_rh(60f32.to_radians(), aspect, 0.1, 100.0);
         engine.renderer.update_camera(&(proj * view));
 
         engine.input.reset();

--- a/src/player.rs
+++ b/src/player.rs
@@ -17,7 +17,9 @@ pub struct Player {
 impl Player {
     pub fn new() -> Self {
         Self {
-            position: Vec3::new(0.0, 1.0, 0.0),
+            // Spawn the player a bit away from the origin so the initial view
+            // isn't clipped by the cube at the center of the scene.
+            position: Vec3::new(0.0, 1.0, 2.0),
             rotation: Quat::IDENTITY,
             yaw: 0.0,
             pitch: 0.0,


### PR DESCRIPTION
## Summary
- ensure player spawns away from the cube
- use a projection matrix with `[0,1]` depth range
- correct floor index winding so it's visible

## Testing
- `cargo check` *(fails: `alsa-sys` missing `alsa` dev package)*

------
https://chatgpt.com/codex/tasks/task_e_68531f83b810832586fcc75bc565d9ad