### PR TITLE
Add pulsating artifact structure

### DIFF
--- a/assets/unlit.wgsl
+++ b/assets/unlit.wgsl
@@ -5,6 +5,13 @@ struct Camera {
 @group(0) @binding(0)
 var<uniform> camera: Camera;
 
+struct Artifact {
+    intensity: f32;
+};
+
+@group(1) @binding(0)
+var<uniform> artifact: Artifact;
+
 struct VertexInput {
     @location(0) position: vec3<f32>;
     @location(1) color: vec3<f32>;
@@ -25,5 +32,5 @@ fn vs_main(in: VertexInput) -> VSOut {
 
 @fragment
 fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
-    return vec4<f32>(in.color, 1.0);
+    return vec4<f32>(in.color * artifact.intensity, 1.0);
 }


### PR DESCRIPTION
## Summary
- draw 28 dark blocks as a ring-shaped artifact
- implement pulsing color effect via a fragment shader uniform
- activate the effect and sound when the player approaches

## Testing
- `cargo check` *(fails: `alsa-sys` missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_685326d779b8832591c691fcff9a1a0b