### PR TITLE
Fix startup panic

### DIFF
--- a/src/engine/audio.rs
+++ b/src/engine/audio.rs
@@ -14,6 +14,9 @@ impl AudioSystem {
     }
 
     pub fn play_bytes(&self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
         if let Ok(decoder) = Decoder::new(Cursor::new(bytes.to_vec())) {
             self.sink.append(decoder);
         }

--- a/src/engine/renderer.rs
+++ b/src/engine/renderer.rs
@@ -55,7 +55,9 @@ impl Renderer {
             height: size.height,
             present_mode: surface_caps.present_modes[0],
             alpha_mode: surface_caps.alpha_modes[0],
-            view_formats: vec![],
+            // Avoid creating an empty slice which may trip debug assertions in
+            // wgpu by providing the surface format here as well.
+            view_formats: vec![surface_format],
         };
         surface.configure(&device, &config);
 


### PR DESCRIPTION
## Summary
- avoid empty byte audio decode that could cause runtime panic
- always pass a non-empty view format to the surface configuration

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68532cad797883258981acd859ec5057