### PR TITLE
Add simple enemy after beacon activation

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -59,13 +59,21 @@ impl Engine {
             match &event {
                 winit::event::Event::WindowEvent { event, .. } => match event {
                     winit::event::WindowEvent::KeyboardInput { input, .. } => {
-                        if let (Some(winit::event::VirtualKeyCode::Escape), winit::event::ElementState::Pressed) = (input.virtual_keycode, input.state) {
+                        if let (
+                            Some(winit::event::VirtualKeyCode::Escape),
+                            winit::event::ElementState::Pressed,
+                        ) = (input.virtual_keycode, input.state)
+                        {
                             if !engine.paused {
                                 engine.pause();
                             }
                         }
                     }
-                    winit::event::WindowEvent::MouseInput { state: winit::event::ElementState::Pressed, button: winit::event::MouseButton::Left, .. } => {
+                    winit::event::WindowEvent::MouseInput {
+                        state: winit::event::ElementState::Pressed,
+                        button: winit::event::MouseButton::Left,
+                        ..
+                    } => {
                         if engine.paused {
                             engine.resume();
                         }
@@ -82,7 +90,7 @@ impl Engine {
                     }
                 }
                 Event::RedrawRequested(_) => {
-                    engine.renderer.render(None);
+                    engine.renderer.render(None, &[]);
                 }
                 Event::WindowEvent { ref event, .. } => {
                     if let Some(size) = engine.window.handle_window_event(event) {


### PR DESCRIPTION
## Summary
- spawn an enemy 5 seconds after the tech activation
- enemy moves toward the player and periodically fires bullets
- bullets damage the player and display a game over message on death
- render dynamic cubes for enemy, gun and bullets

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685338ffcd908325938d74f7f085b9eb